### PR TITLE
Debug flag set automatically when tests are run

### DIFF
--- a/backend/tests/endpoints/__init__.py
+++ b/backend/tests/endpoints/__init__.py
@@ -1,8 +1,11 @@
+import os
 from typing import Any
 
 from httpx import Response
 from starlette import status
 from starlette.testclient import TestClient
+
+os.environ["DELPHI_DEBUG"] = "1"
 
 
 def assert_status_code(response: Response, expected_status_code: int) -> None:


### PR DESCRIPTION
Wanneer de debug variabele niet aanstaat slagen sommige testen niet met `poetry run python -m unittest discover tests`. De code zet het debug variabele aan tijdens de testen zodat dit lokaal niet aangezet moet worden.