### PR TITLE
fix: show error when link is wrong etc

### DIFF
--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -47,7 +47,7 @@ import joinCourse, {JOIN_COURSE} from "./dataloaders/JoinCourse.ts";
 
 const router = createBrowserRouter(
     createRoutesFromElements(
-        <Route path={"/"}>
+        <Route path={"/"} errorElement={<ErrorPage/>}>
 
             {/* Public routes */}
             <Route path={"login"} id={LOGIN_ROUTER_ID} element={<LoginScreen/>} loader={loginLoader}


### PR DESCRIPTION
Closes #280

Nu kan je een foute link ingeven en zal het de errorpagina wel tonen.